### PR TITLE
Update opentelemetry-semconv and opentelemetry-aws-xray-propagator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,25 +36,31 @@ lazy val core = project.in(file("core"))
   .settings(
     name := "dwolla-otel-natchez",
     description := "Utilities for configuring a Natchez EntryPoint for OpenTelemetry at Dwolla",
-    libraryDependencies ++= Seq(
-      "org.tpolecat" %% "natchez-core" % "0.3.5",
-      "org.tpolecat" %% "natchez-opentelemetry" % "0.3.5",
-      "org.typelevel" %% "cats-core" % "2.12.0",
-      "org.typelevel" %% "cats-effect" % catsEffectV,
-      "org.typelevel" %% "cats-mtl" % "1.5.0",
-      "org.typelevel" %% "log4cats-core" % "2.7.0",
-      "io.circe" %% "circe-literal" % "0.14.9",
-      "org.typelevel" %% "jawn-parser" % "1.6.0" % Provided,
-      "io.opentelemetry" % "opentelemetry-api" % otelApiV,
-      "io.opentelemetry" % "opentelemetry-context" % "1.41.0",
-      "io.opentelemetry" % "opentelemetry-exporter-otlp" % "1.41.0",
-      "io.opentelemetry" % "opentelemetry-extension-trace-propagators" % "1.41.0",
-      "io.opentelemetry" % "opentelemetry-sdk" % "1.41.0",
-      "io.opentelemetry" % "opentelemetry-sdk-common" % "1.41.0",
-      "io.opentelemetry" % "opentelemetry-sdk-trace" % otelTraceSdkV,
-      "io.opentelemetry.semconv" % "opentelemetry-semconv" % "1.23.1-alpha",
-      "io.opentelemetry.contrib" % "opentelemetry-aws-xray-propagator" % "1.32.0-alpha",
-    ),
+    libraryDependencies ++= {
+      val otelSemConvV = "1.27.0-alpha"
+
+      Seq(
+        "org.tpolecat" %% "natchez-core" % "0.3.5",
+        "org.tpolecat" %% "natchez-opentelemetry" % "0.3.5",
+        "org.typelevel" %% "cats-core" % "2.12.0",
+        "org.typelevel" %% "cats-effect" % catsEffectV,
+        "org.typelevel" %% "cats-mtl" % "1.5.0",
+        "org.typelevel" %% "log4cats-core" % "2.7.0",
+        "io.circe" %% "circe-literal" % "0.14.9",
+        "org.typelevel" %% "jawn-parser" % "1.6.0" % Provided,
+        "io.opentelemetry" % "opentelemetry-api" % otelApiV,
+        "io.opentelemetry" % "opentelemetry-context" % "1.41.0",
+        "io.opentelemetry" % "opentelemetry-exporter-otlp" % "1.41.0",
+        "io.opentelemetry" % "opentelemetry-extension-trace-propagators" % "1.41.0",
+        "io.opentelemetry" % "opentelemetry-sdk" % "1.41.0",
+        "io.opentelemetry" % "opentelemetry-sdk-common" % "1.41.0",
+        "io.opentelemetry" % "opentelemetry-sdk-trace" % otelTraceSdkV,
+        "io.opentelemetry.contrib" % "opentelemetry-aws-xray-propagator" % "1.32.0-alpha",
+        "io.opentelemetry.semconv" % "opentelemetry-semconv" % otelSemConvV % Test,
+        "io.opentelemetry.semconv" % "opentelemetry-semconv-incubating" % otelSemConvV % Test,
+        "org.scalameta" %% "munit" % "1.0.1" % Test,
+      )
+    },
   )
   .dependsOn(`aws-xray-id-generator`)
 

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val core = project.in(file("core"))
         "io.opentelemetry" % "opentelemetry-sdk" % "1.41.0",
         "io.opentelemetry" % "opentelemetry-sdk-common" % "1.41.0",
         "io.opentelemetry" % "opentelemetry-sdk-trace" % otelTraceSdkV,
-        "io.opentelemetry.contrib" % "opentelemetry-aws-xray-propagator" % "1.32.0-alpha",
+        "io.opentelemetry.contrib" % "opentelemetry-aws-xray-propagator" % "1.38.0-alpha",
         "io.opentelemetry.semconv" % "opentelemetry-semconv" % otelSemConvV % Test,
         "io.opentelemetry.semconv" % "opentelemetry-semconv-incubating" % otelSemConvV % Test,
         "org.scalameta" %% "munit" % "1.0.1" % Test,

--- a/core/src/main/scala/com/dwolla/tracing/OpenTelemetryAtDwolla.scala
+++ b/core/src/main/scala/com/dwolla/tracing/OpenTelemetryAtDwolla.scala
@@ -13,7 +13,6 @@ import io.opentelemetry.extension.trace.propagation.B3Propagator
 import io.opentelemetry.sdk.resources.Resource as OTResource
 import io.opentelemetry.sdk.trace.`export`.{BatchSpanProcessor, SimpleSpanProcessor}
 import io.opentelemetry.sdk.trace.{SdkTracerProvider, SdkTracerProviderBuilder, SpanProcessor}
-import io.opentelemetry.semconv.ResourceAttributes
 import natchez.*
 import natchez.opentelemetry.OpenTelemetry
 import org.typelevel.log4cats.LoggerFactory
@@ -91,9 +90,9 @@ object OpenTelemetryAtDwolla {
                             .merge(OTResource.create {
                               version.foldl {
                                 Attributes.builder()
-                                  .put(ResourceAttributes.SERVICE_NAME, serviceName)
-                                  .put(ResourceAttributes.DEPLOYMENT_ENVIRONMENT, env.name)
-                              }(_.put(ResourceAttributes.SERVICE_VERSION, _))
+                                  .put(OtelAttributes.serviceName, serviceName)
+                                  .put(OtelAttributes.deploymentEnvironmentName, env.name)
+                              }(_.put(OtelAttributes.serviceVersion, _))
                                 .build()
                             })
                         }

--- a/core/src/main/scala/com/dwolla/tracing/OtelAttributes.scala
+++ b/core/src/main/scala/com/dwolla/tracing/OtelAttributes.scala
@@ -1,0 +1,24 @@
+package com.dwolla.tracing
+
+import io.opentelemetry.api.common.AttributeKey.stringKey
+
+/**
+ * The [[https://github.com/open-telemetry/semantic-conventions-java?tab=readme-ov-file#published-releases
+ * documentation for `io.opentelemetry.semconv:opentelemetry-semconv-incubating` states]]:
+ *
+ * <blockquote>'''NOTE:''' This artifact has the -alpha and comes with no compatibility
+ * guarantees. Libraries can use this for testing, but should make copies of the attributes
+ * to avoid possible runtime errors from version conflicts.</blockquote>
+ *
+ * The documentation for `io.opentelemetry.semconv:opentelemetry-semconv` states that its
+ * semantic conventions are stable, but that the artifact itself comes with no compatibility
+ * guarantees.
+ *
+ * Therefore, to avoid any issues, we copy the attributes we'll use, and only use the
+ * artifacts in tests to confirm that the keys are properly defined.
+ */
+private[tracing] object OtelAttributes {
+  private[tracing] val serviceName = stringKey("service.name")
+  private[tracing] val serviceVersion = stringKey("service.version")
+  private[tracing] val deploymentEnvironmentName = stringKey("deployment.environment.name")
+}

--- a/core/src/test/scala/com/dwolla/tracing/OtelAttributeNameSpec.scala
+++ b/core/src/test/scala/com/dwolla/tracing/OtelAttributeNameSpec.scala
@@ -1,0 +1,21 @@
+package com.dwolla.tracing
+
+import io.opentelemetry.semconv.ServiceAttributes
+import io.opentelemetry.semconv.incubating.DeploymentIncubatingAttributes
+import munit.FunSuite
+
+class OtelAttributeNameSpec extends FunSuite {
+
+  test("Service Name") {
+    assertEquals(OtelAttributes.serviceName, ServiceAttributes.SERVICE_NAME)
+  }
+
+  test("Service Version") {
+    assertEquals(OtelAttributes.serviceVersion, ServiceAttributes.SERVICE_VERSION)
+  }
+
+  test("Deployment Environment") {
+    assertEquals(OtelAttributes.deploymentEnvironmentName, DeploymentIncubatingAttributes.DEPLOYMENT_ENVIRONMENT_NAME)
+  }
+
+}


### PR DESCRIPTION
Updating `io.opentelemetry.semconv:opentelemetry-semconv` brought in some deprecations, which this PR addresses.