### PR TITLE
Tweak config to keep gRPC exports under 4MB

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val core = project.in(file("core"))
         "io.opentelemetry" % "opentelemetry-sdk" % "1.54.0",
         "io.opentelemetry" % "opentelemetry-sdk-common" % "1.54.0",
         "io.opentelemetry" % "opentelemetry-sdk-trace" % otelTraceSdkV,
-        "io.opentelemetry.contrib" % "opentelemetry-aws-xray-propagator" % "1.38.0-alpha",
+        "io.opentelemetry.contrib" % "opentelemetry-aws-xray-propagator" % "1.49.0-alpha",
         "io.opentelemetry.semconv" % "opentelemetry-semconv" % "1.37.0" % Test,
         "io.opentelemetry.semconv" % "opentelemetry-semconv-incubating" % "1.32.0-alpha" % Test,
         "org.scalameta" %% "munit" % "1.2.0" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ lazy val core = project.in(file("core"))
         "io.opentelemetry" % "opentelemetry-sdk-trace" % otelTraceSdkV,
         "io.opentelemetry.contrib" % "opentelemetry-aws-xray-propagator" % "1.49.0-alpha",
         "io.opentelemetry.semconv" % "opentelemetry-semconv" % "1.37.0" % Test,
-        "io.opentelemetry.semconv" % "opentelemetry-semconv-incubating" % "1.32.0-alpha" % Test,
+        "io.opentelemetry.semconv" % "opentelemetry-semconv-incubating" % "1.37.0-alpha" % Test,
         "org.scalameta" %% "munit" % "1.2.0" % Test,
       )
     },

--- a/core/src/main/scala/com/dwolla/tracing/OpenTelemetryAtDwolla.scala
+++ b/core/src/main/scala/com/dwolla/tracing/OpenTelemetryAtDwolla.scala
@@ -60,7 +60,10 @@ object OpenTelemetryAtDwolla {
         .flatMap { endpoint =>
           val otelSpanExporter = Sync[F].delay {
             val builder =
-              endpoint.foldl(OtlpGrpcSpanExporter.builder())(_ setEndpoint _).build()
+              endpoint
+                .foldl(OtlpGrpcSpanExporter.builder())(_ setEndpoint _)
+                .setCompression("gzip")
+                .build()
 
             BatchSpanProcessor.builder(builder).build()
           }

--- a/core/src/main/scala/com/dwolla/tracing/OpenTelemetryAtDwolla.scala
+++ b/core/src/main/scala/com/dwolla/tracing/OpenTelemetryAtDwolla.scala
@@ -65,7 +65,10 @@ object OpenTelemetryAtDwolla {
                 .setCompression("gzip")
                 .build()
 
-            BatchSpanProcessor.builder(builder).build()
+            BatchSpanProcessor
+              .builder(builder)
+              .setMaxExportBatchSize(128) // Configure smaller export batches to ensure payloads remain well under 4 MiB
+              .build()
           }
 
           Resource.fromAutoCloseable(otelSpanExporter)


### PR DESCRIPTION
This enables Gzip compression and uses smaller batch sizes to keep exports well under the 4MB limit defined by our OTel collector.